### PR TITLE
Fix spaces in paths and paths ending in backslash followed by quote

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -168,13 +168,16 @@ pub fn prepare_cmd(cmd: &str, file_path: &Path) -> Option<Vec<String>> {
     let exe_path = file_path.with_extension(EXE_EXTENSION);
     let file_name_no_ext = file_path.file_stem().unwrap().to_str().unwrap();
 
-    let cmd = cmd
-        .replace("$SRC_PATH", &path_to_str(file_path))
-        .replace("$SRC_FILE_NAME_NO_EXT", file_name_no_ext)
-        .replace("$DIR_PATH", &path_to_str(&dir_path))
-        .replace("$EXE_PATH", &path_to_str(&exe_path));
-
-    shlex::split(&cmd)
+    shlex::split(&cmd).map(|args| {
+        args.iter()
+            .map(|arg| {
+                arg.replace("$SRC_PATH", &path_to_str(file_path))
+                    .replace("$SRC_FILE_NAME_NO_EXT", file_name_no_ext)
+                    .replace("$DIR_PATH", &path_to_str(&dir_path))
+                    .replace("$EXE_PATH", &path_to_str(&exe_path))
+            })
+            .collect()
+    })
 }
 
 pub struct Kattisrc {

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,7 @@ pub fn prepare_cmd(cmd: &str, file_path: &Path) -> Option<Vec<String>> {
     let exe_path = file_path.with_extension(EXE_EXTENSION);
     let file_name_no_ext = file_path.file_stem().unwrap().to_str().unwrap();
 
-    shlex::split(&cmd).map(|args| {
+    shlex::split(cmd).map(|args| {
         args.iter()
             .map(|arg| {
                 arg.replace("$SRC_PATH", &path_to_str(file_path))

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -74,7 +74,7 @@ impl<'a> Problem<'a> {
         // If you run a command such as `kitty test '.\test folder\skocimis\'`,
         // the evaluated path is .\test folder\skocimis\" (notice the trailing
         // quotation mark) - we protect against that here.
-        let path_str = if path_arg.ends_with("\"") {
+        let path_str = if path_arg.ends_with('"') {
             path_arg.chars().take(path_arg.len() - 1).collect()
         } else {
             path_arg.to_string()

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -71,7 +71,16 @@ impl<'a> Problem<'a> {
     }
 
     pub fn get_path(path_arg: &str) -> Result<PathBuf, StdErr> {
-        let rel_path = Path::new(path_arg).to_path_buf();
+        // If you run a command such as `kitty test '.\test folder\skocimis\'`,
+        // the evaluated path is .\test folder\skocimis\" (notice the trailing
+        // quotation mark) - we protect against that here.
+        let path_str = if path_arg.ends_with("\"") {
+            path_arg.chars().take(path_arg.len() - 1).collect()
+        } else {
+            path_arg.to_string()
+        };
+
+        let rel_path = Path::new(&path_str).to_path_buf();
 
         let path = if rel_path.is_absolute() {
             rel_path
@@ -80,14 +89,12 @@ impl<'a> Problem<'a> {
             cwd.join(rel_path)
         };
 
-        let path_str = path.to_str().expect("path did not contain valid unicode");
-
         if !path.exists() {
-            return Err(format!("not found: {}", path_str).into());
+            return Err(format!("not found: {}", path.display()).into());
         }
 
         if !path.is_dir() {
-            return Err(format!("not a directory: {}", path_str).into());
+            return Err(format!("not a directory: {}", path.display()).into());
         }
 
         Ok(path)


### PR DESCRIPTION
The following command would fail for two reasons `kitty test '.\test folder\skocimis\'`:
1. The path was substituted into the run and compile command before splitting the commands, so the space in the path would cause the commands to receive the source file as `.\test`.
2. `clap`, because of the ending `\'`, returns the path `.\test folder\skocimis"` (notice the `"`) - which does not exist.

Closes #40, closes #41.