### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/commands/random.rs
+++ b/src/commands/random.rs
@@ -48,9 +48,7 @@ pub async fn random(cmd: &ArgMatches<'_>) -> Result<(), StdErr> {
     Ok(())
 }
 
-#[derive(Debug)]
 struct SimpleProblem {
-    name: String,
     id: String,
     difficulty: String,
 }
@@ -107,7 +105,6 @@ async fn get_front_page_problems(cmd: &ArgMatches<'_>) -> Result<Vec<SimpleProbl
             Some(t) => t,
             None => continue,
         };
-        let name: String = name_el.text().collect();
         let id_match = name_el
             .value()
             .attr("href")
@@ -124,11 +121,7 @@ async fn get_front_page_problems(cmd: &ArgMatches<'_>) -> Result<Vec<SimpleProbl
             None => continue,
         };
 
-        problems.push(SimpleProblem {
-            name,
-            id,
-            difficulty,
-        });
+        problems.push(SimpleProblem { id, difficulty });
     }
 
     Ok(problems)

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,11 +112,7 @@ mod config_parser {
         let default_language = doc["default_language"].as_str().map(str::to_string);
         let languages = doc["languages"]
             .as_vec()
-            .map(|v| {
-                v.iter()
-                    .map(|b| lang_from_yml(b))
-                    .collect::<Result<Vec<_>, _>>()
-            })
+            .map(|v| v.iter().map(lang_from_yml).collect::<Result<Vec<_>, _>>())
             .unwrap_or_else(|| Ok(Vec::new()))?;
 
         let config = Config {


### PR DESCRIPTION
Rust and Clippy have been updated since the last green check on master. Thus new changes will fail due to warnings that are also applicable to master.