### PR TITLE
Add flag to filter which tests to run

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,8 +153,20 @@ pub struct TestArgs {
     #[arg(short, long, default_value_t = false)]
     pub watch: bool,
 
-    /// Filter which tests to run. Only tests whose name contain the given
-    /// filter will be used.
+    /// Filter which tests to run. Filters are written using regular
+    /// expressions to match on test names.
+    ///
+    /// This can be useful for focusing on a few specific test cases when
+    /// debugging.
+    ///
+    /// Here are some examples:
+    /// Only tests containing "custom": --filter custom.
+    /// Only the exact test named "custom01": --filter '^custom01$'.
+    /// Only tests that are named one of the numbers from 1 to 5: --filter '^[1-5]$'.
+    ///
+    /// Note that (depending on your shell), you may have to use quotes around
+    /// the filter since the shell may try to expand the regular expression as a
+    /// glob pattern.
     #[arg(short = 'F', long)]
     pub filter: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,11 @@ pub struct TestArgs {
     /// Re-runs tests every time the source file changes.
     #[arg(short, long, default_value_t = false)]
     pub watch: bool,
+
+    /// Filter which tests to run. Only tests whose name contain the given
+    /// filter will be used.
+    #[arg(short = 'F', long)]
+    pub filter: Option<String>,
 }
 
 /// Opens a problem in the browser

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -9,6 +9,7 @@ use std::{
 use colored::Colorize;
 use eyre::{bail, Context};
 use notify::{event::ModifyKind, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use regex::Regex;
 
 use crate::{
     cli::TestArgs,
@@ -63,8 +64,10 @@ fn run_tests(
     let mut test_cases = get_test_cases(&solution.dir)?;
 
     if let Some(filter) = &args.filter {
-        let filter = filter.to_lowercase();
-        test_cases.retain(|test_case| test_case.name.to_lowercase().contains(&filter));
+        let regex_filter = Regex::new(filter)
+            .wrap_err("The given test case filter was an invalid regular expression")?;
+
+        test_cases.retain(|test_case| regex_filter.is_match(&test_case.name));
     }
 
     let mut num_failed_tests = 0;

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -60,7 +60,13 @@ fn run_tests(
         run_compile_cmd(app, compile_cmd)?;
     }
 
-    let test_cases = get_test_cases(&solution.dir)?;
+    let mut test_cases = get_test_cases(&solution.dir)?;
+
+    if let Some(filter) = &args.filter {
+        let filter = filter.to_lowercase();
+        test_cases.retain(|test_case| test_case.name.to_lowercase().contains(&filter));
+    }
+
     let mut num_failed_tests = 0;
 
     println!("Running {} tests\n", test_cases.len());

--- a/tests/kitty-cli/get.rs
+++ b/tests/kitty-cli/get.rs
@@ -16,7 +16,7 @@ fn creates_folders_and_downloads_tests() {
 
             env.run("kitty get quadrant")
                 .await
-                .assert(StdOut, contains("created solution folder for quadrant"));
+                .assert(StdOut, contains("Created solution folder for quadrant"));
 
             env.run("ls").await.assert(StdOut, contains("quadrant"));
 

--- a/tests/kitty-cli/test.rs
+++ b/tests/kitty-cli/test.rs
@@ -207,7 +207,7 @@ fn filter_only_runs_matching_tests() {
                     "#}),
                 );
 
-            env.run("cd quadrant && kitty test --filter custom")
+            env.run("cd quadrant && kitty test --filter '^custom'")
                 .await
                 .assert(
                     StdOut,

--- a/tests/kitty-cli/test.rs
+++ b/tests/kitty-cli/test.rs
@@ -179,3 +179,48 @@ fn language_override_works() {
         .boxed()
     }));
 }
+
+#[test]
+fn filter_only_runs_matching_tests() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+
+            env.run("cd quadrant/test && cp 1.in custom01.in").await;
+            env.run("cd quadrant/test && cp 1.ans custom01.ans").await;
+            env.run("cd quadrant/test && cp 2.in custom02.in").await;
+            env.run("cd quadrant/test && cp 2.ans custom02.ans").await;
+
+            env.run("cd quadrant && kitty test --filter 1")
+                .await
+                .assert(
+                    StdOut,
+                    contains(indoc::indoc! {r#"
+                        Running 2 tests
+
+                        test 1 ... ✅
+                        test custom01 ... ✅
+
+                        Test result: ok. 2 passed; 0 failed.
+                    "#}),
+                );
+
+            env.run("cd quadrant && kitty test --filter custom")
+                .await
+                .assert(
+                    StdOut,
+                    contains(indoc::indoc! {r#"
+                        Running 2 tests
+
+                        test custom01 ... ✅
+                        test custom02 ... ✅
+
+                        Test result: ok. 2 passed; 0 failed.
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}


### PR DESCRIPTION
This PR introduces a new `--filter`/`-F` flag to the `kitty test` command, which lets you filter which tests should be run. It may be useful to focus on a single test when debugging rather than a large test output, and this flag assists you in that.

Closes #63