### PR TITLE
Add debug command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ Python 3   py
 Rust       rs
 ```
 
+### Testing programmatically
+
+There may be cases where you want to automatically generate test cases with a program. To do this, `kitty` has the `debug input` command that will feed whatever your input generator outputs into your solution program:
+
+```sh
+kitty debug input
+```
+
+The logical equivalence of this command is running `run-solution < $(run-input-generator)` *n* times or until a runtime error occurs.
+
+See the help message for how to create the input generator and specify the number of iterations. By default, `kitty` uses the file at `<solution folder>/debug/input.<extension>`.
+
+On top of this, you can use `kitty` to automatically check your solution's answer against another implementation. For instance, you may be able to implement a correct but slow solution. When developing the faster solution, you can use the slow solution to check that the new version outputs the correct answers across automatically generated inputs:
+
+```sh
+kitty debug answer
+```
+
+This is logically equivalent to `kitty test` but where the `.in` file is replaced with an input generator program and the `.ans` file is replaced with an answer validator program.
+
+See the help message for more information. By default, `kitty` uses the file at `<solution folder>/debug/answer.<extension>`.
+
 ## Installation
 ### Installation script (Windows only)
 You can use the following PowerShell command to install kitty. This will download the latest binary and a default config file.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,7 @@ pub struct KittyArgs {
 #[derive(Subcommand, Debug)]
 pub enum KittySubcommand {
     Config(ConfigArgs),
+    Debug(DebugArgs),
     Get(GetArgs),
     Open(OpenArgs),
     Submit(SubmitArgs),
@@ -214,4 +215,83 @@ pub struct SubmitArgs {
     /// Open the submission on Kattis in your browser.
     #[arg(short, long, default_value_t = false)]
     pub open: bool,
+}
+
+/// Instead of using the static test files in the test folder, use custom
+/// programs to generate input for your solution and to verify your solution's
+/// output.
+#[derive(Args, Debug)]
+pub struct DebugArgs {
+    #[command(subcommand)]
+    pub subcommand: DebugSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DebugSubcommand {
+    Input(DebugInputArgs),
+    Answer(DebugAnswerArgs),
+}
+
+/// Instead of using the static test files in the test folder, use a generator
+/// program to generate input for your solution. Your generator's stdout will be
+/// piped into your solution's stdin.
+///
+/// The 'input' command is mostly useful for detecting runtime errors or to see
+/// how your solution scales with large inputs. See the 'answer' command for how
+/// to validate your solution's output.
+///
+/// The generator should be located in the 'debug' subfolder of your solution
+/// folder. By default, the file named 'input' will be used (for example
+/// 'input.py').
+///
+/// The input generator program can be written in any language you have defined
+/// in your config file, just like with the test command.
+#[derive(Args, Debug)]
+pub struct DebugInputArgs {
+    /// The path to the solution folder you want to test
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Path to the solution file to test.
+    ///
+    /// See the test command for more.
+    #[arg(short, long)]
+    pub file: Option<PathBuf>,
+
+    /// Programming language to use for the solution.
+    ///
+    /// See the test command for more.
+    #[arg(short, long)]
+    pub lang: Option<String>,
+
+    /// The path to the input generator file. By default the file named
+    /// 'input' will be used (for example 'input.py').
+    #[arg(short, long = "input-generator")]
+    pub input_generator_path: Option<PathBuf>,
+
+    /// The number of test cases to generate and execute.
+    #[arg(short, long, default_value = "100")]
+    pub num_tests: usize,
+}
+
+/// For cases where you can write a solution that is correct but too slow for
+/// Kattis, you can use this solution to check that your new solution outputs
+/// the same as the old solution.
+///
+/// The 'answer' command uses the input generator described in the 'input'
+/// command's help text. The same input will be piped into your solution and the
+/// answer validator, and then the two programs' output will be compared.
+///
+/// The output validator should be located in the 'debug' subfolder of your
+/// solution folder. By default, the file named 'answer' will be used (for
+/// example 'answer.py').
+#[derive(Args, Debug)]
+pub struct DebugAnswerArgs {
+    #[command(flatten)]
+    pub input_args: DebugInputArgs,
+
+    /// The path to the answer validator file. By default the file named
+    /// 'answer' will be used (for example 'answer.py').
+    #[arg(short, long = "answer-validator")]
+    pub answer_validator_path: Option<PathBuf>,
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -149,7 +149,7 @@ fn run_with_generators(
         })
         .transpose()?;
 
-    let test_case = TestCaseViaGenerator {
+    let test_case = GeneratorTestCase {
         app,
         input_generator_run_cmd: input_gen_exec_cmds.run_cmd(),
         answer_generator_run_cmd: answer_validator_run_cmd.as_deref(),
@@ -185,13 +185,13 @@ fn run_with_generators(
     Ok(Ok(GeneratorSuccess { execution_time }))
 }
 
-struct TestCaseViaGenerator<'a> {
+struct GeneratorTestCase<'a> {
     app: &'a App,
     input_generator_run_cmd: &'a [String],
     answer_generator_run_cmd: Option<&'a [String]>,
 }
 
-impl TestCaseIO for TestCaseViaGenerator<'_> {
+impl TestCaseIO for GeneratorTestCase<'_> {
     type Input<'a> = io::Cursor<Vec<u8>> where Self: 'a;
     type Answer<'a> = io::Cursor<Vec<u8>> where Self: 'a;
 

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -10,17 +10,13 @@ use eyre::{bail, Context};
 
 use crate::{
     cli::{DebugAnswerArgs, DebugArgs, DebugInputArgs, DebugSubcommand},
-    commands::test::{
-        print_test_case_error, run_compile_cmd, run_test, run_with_input, TestCaseError, FAILURE,
-        SUCCESS,
-    },
+    commands::test::{FAILURE, SUCCESS},
     config::language::Language,
     solution::{get_all_files_with_known_extension, get_debug_dir, Solution, SolutionOptions},
+    test_io::{run_compile_cmd, run_test, run_with_input, TestCaseError, TestCaseIO},
     utils::{resolve_and_get_file_name, RunningAverager, TimedPrinter},
     App,
 };
-
-use super::test::TestCaseIO;
 
 // TODO: Only compile generators and solution once
 pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
@@ -61,7 +57,7 @@ pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
         if let Err(failure) = outcome {
             println!("{FAILURE}\n");
 
-            print_test_case_error(&failure.test_case_error);
+            failure.test_case_error.print();
 
             println!("{}:", "Input".bright_red());
             println!("{}\n", failure.test_case_error.input().trim_end());

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -2,28 +2,49 @@ use std::{
     io::{self, Read},
     path::{Path, PathBuf},
     process,
+    sync::{RwLock, RwLockReadGuard},
     time::{Duration, Instant},
 };
 
 use color_eyre::owo_colors::OwoColorize;
-use eyre::{bail, Context};
+use eyre::{bail, eyre, Context};
 
 use crate::{
     cli::{DebugAnswerArgs, DebugArgs, DebugInputArgs, DebugSubcommand},
     commands::test::{FAILURE, SUCCESS},
-    config::language::Language,
-    solution::{get_all_files_with_known_extension, get_debug_dir, Solution, SolutionOptions},
+    config::language::{ExecuteProgramCommands, Language},
+    solution::{get_all_files_with_known_extension, Solution, SolutionOptions},
     test_io::{run_compile_cmd, run_test, run_with_input, TestCaseError, TestCaseIO},
     utils::{resolve_and_get_file_name, RunningAverager, TimedPrinter},
     App,
 };
 
-// TODO: Only compile generators and solution once
 pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
-    let input_args = match &args.subcommand {
-        DebugSubcommand::Input(input_args) => input_args,
-        DebugSubcommand::Answer(answer_args) => &answer_args.input_args,
-    };
+    let input_args = args.input_args();
+    let solution = Solution::from_folder(
+        app,
+        &input_args.path,
+        SolutionOptions {
+            file_path: input_args.file.as_ref(),
+            lang: input_args.lang.as_ref(),
+        },
+    )?;
+
+    eyre::ensure!(
+        solution.debug_dir().is_dir(),
+        "You don't have a debug folder. Create it at: {}",
+        solution.debug_dir().display().underline()
+    );
+
+    let solution_exec_cmds = solution
+        .lang
+        .get_program_execution_commands(&solution.file)?;
+
+    if let Some(compile_cmd) = solution_exec_cmds.compile_cmd() {
+        run_compile_cmd(app, compile_cmd)?;
+    }
+
+    let generators = GeneratorTestCase::new(app, &solution, args);
 
     let num_tests = input_args.num_tests;
 
@@ -36,12 +57,7 @@ pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
             n == num_tests,
         )?;
 
-        let result = match &args.subcommand {
-            DebugSubcommand::Input(input_args) => run_with_generators(app, input_args, None),
-            DebugSubcommand::Answer(answer_args) => {
-                run_with_generators(app, input_args, Some(answer_args))
-            }
-        };
+        let result = test_solution_with_generators(app, &solution, &generators);
 
         if result.is_err() {
             println!("{FAILURE}\n");
@@ -88,85 +104,19 @@ pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
     Ok(())
 }
 
-fn run_with_generators(
+fn test_solution_with_generators(
     app: &App,
-    input_args: &DebugInputArgs,
-    answer_args: Option<&DebugAnswerArgs>,
+    solution: &Solution,
+    test_case: &GeneratorTestCase<'_>,
 ) -> crate::Result<Result<GeneratorSuccess, GeneratorError>> {
-    let solution = Solution::from_folder(
-        app,
-        &input_args.path,
-        SolutionOptions {
-            file_path: input_args.file.as_ref(),
-            lang: input_args.lang.as_ref(),
-        },
-    )?;
-
-    let debug_dir = get_debug_dir(&solution.dir);
-
-    eyre::ensure!(
-        get_debug_dir(&solution.dir).is_dir(),
-        "You don't have a debug folder. Create it at: {}",
-        debug_dir.display().underline()
-    );
-
-    let (input_generator_path, input_generator_lang) = resolve_generator_file_to_use(
-        app,
-        "input",
-        &debug_dir,
-        input_args.input_generator_path.as_ref(),
-    )?;
-
-    let input_gen_exec_cmds =
-        input_generator_lang.get_program_execution_commands(input_generator_path)?;
-
-    if let Some(compile_cmd) = input_gen_exec_cmds.compile_cmd() {
-        run_compile_cmd(app, compile_cmd).wrap_err("Failed to compile your input generator")?;
-    }
-
-    let answer_validator_run_cmd = answer_args
-        .map(|answer_args| -> crate::Result<_> {
-            let (answer_validator_path, answer_validator_lang) = resolve_generator_file_to_use(
-                app,
-                "answer",
-                &debug_dir,
-                answer_args.answer_validator_path.as_ref(),
-            )?;
-
-            let answer_validator_exec_cmds =
-                answer_validator_lang.get_program_execution_commands(answer_validator_path)?;
-
-            if let Some(compile_cmd) = answer_validator_exec_cmds.compile_cmd() {
-                run_compile_cmd(app, compile_cmd)
-                    .wrap_err("Failed to compile your answer validator")?;
-            }
-
-            Ok(answer_validator_exec_cmds.run_cmd().to_vec())
-        })
-        .transpose()?;
-
-    let test_case = GeneratorTestCase {
-        app,
-        input_generator_run_cmd: input_gen_exec_cmds.run_cmd(),
-        answer_generator_run_cmd: answer_validator_run_cmd.as_deref(),
-    };
-
-    let solution_exec_cmds = solution
-        .lang
-        .get_program_execution_commands(&solution.file)?;
-
-    if let Some(compile_cmd) = solution_exec_cmds.compile_cmd() {
-        run_compile_cmd(app, compile_cmd)?;
-    }
-
     let start_time = Instant::now();
-    let test_result = run_test(app, &solution.lang.get_run_cmd(&solution.file)?, &test_case)?;
+    let test_result = run_test(app, &solution.lang.get_run_cmd(&solution.file)?, test_case)?;
     let execution_time = start_time.elapsed();
 
     if let Err(test_case_error) = test_result {
         let should_return_error = match test_case_error {
             TestCaseError::RuntimeError { .. } => true,
-            TestCaseError::WrongAnswer { .. } if answer_args.is_some() => true,
+            TestCaseError::WrongAnswer { .. } if test_case.should_check_answer() => true,
             _ => false,
         };
 
@@ -181,10 +131,17 @@ fn run_with_generators(
     Ok(Ok(GeneratorSuccess { execution_time }))
 }
 
+type LazilyInitialised<T> = RwLock<Option<T>>;
+
 struct GeneratorTestCase<'a> {
     app: &'a App,
-    input_generator_run_cmd: &'a [String],
-    answer_generator_run_cmd: Option<&'a [String]>,
+    solution: &'a Solution<'a>,
+    input_args: &'a DebugInputArgs,
+    answer_args: Option<&'a DebugAnswerArgs>,
+    // Use read-write locks to achieve interior mutability, which we use to only
+    // perform initialisation once (i.e. file search and compilation).
+    input_generator_exec_cmds: LazilyInitialised<ExecuteProgramCommands>,
+    answer_generator_exec_cmds: LazilyInitialised<Option<ExecuteProgramCommands>>,
 }
 
 impl TestCaseIO for GeneratorTestCase<'_> {
@@ -192,8 +149,37 @@ impl TestCaseIO for GeneratorTestCase<'_> {
     type Answer<'a> = io::Cursor<Vec<u8>> where Self: 'a;
 
     fn input(&self) -> crate::Result<Self::Input<'_>> {
+        if !self.has_initialised_input_generator()? {
+            let mut initialiser_guard = self
+                .input_generator_exec_cmds
+                .write()
+                .map_err(|_| eyre::eyre!("Failed to lock input generator"))?;
+
+            let (input_generator_path, input_generator_lang) = resolve_generator_file_to_use(
+                self.app,
+                "input",
+                self.solution.debug_dir(),
+                self.input_args.input_generator_path.as_ref(),
+            )?;
+
+            let exec_cmds =
+                input_generator_lang.get_program_execution_commands(input_generator_path)?;
+
+            if let Some(compile_cmd) = exec_cmds.compile_cmd() {
+                run_compile_cmd(self.app, compile_cmd)
+                    .wrap_err("Failed to compile your input generator")?;
+            }
+
+            *initialiser_guard = Some(exec_cmds);
+        }
+
+        let exec_cmds_guard = self.get_input_generator_exec_cmds()?;
+        let exec_cmds = exec_cmds_guard.as_ref().ok_or_else(|| {
+            eyre!("Failed to get input generator run command. This is a bug, please report it!")
+        })?;
+
         let input_generator_output =
-            run_with_input(self.app, self.input_generator_run_cmd, &mut io::empty())?;
+            run_with_input(self.app, exec_cmds.run_cmd(), &mut io::empty())?;
 
         fail_if_output_is_not_success("input", &input_generator_output)?;
 
@@ -201,22 +187,101 @@ impl TestCaseIO for GeneratorTestCase<'_> {
     }
 
     fn answer<R: Read>(&self, input: Option<R>) -> crate::Result<Self::Answer<'_>> {
-        let answer_generator_run_cmd = match self.answer_generator_run_cmd {
-            Some(answer_generator_run_cmd) => answer_generator_run_cmd,
-            None => return Ok(io::Cursor::new(Vec::new())),
-        };
-
         let mut input: Box<dyn Read> = match input {
             Some(input) => Box::new(input),
             None => Box::new(io::empty()),
         };
 
-        let answer_generator_output =
-            run_with_input(self.app, answer_generator_run_cmd, &mut input)?;
+        if !self.has_initialised_answer_generator()? {
+            let mut initialiser_guard = self
+                .answer_generator_exec_cmds
+                .write()
+                .map_err(|_| eyre::eyre!("Failed to lock answer generator"))?;
+
+            let exec_cmds = match self.answer_args {
+                None => None,
+                Some(answer_args) => {
+                    let (answer_validator_path, answer_validator_lang) =
+                        resolve_generator_file_to_use(
+                            self.app,
+                            "answer",
+                            self.solution.debug_dir(),
+                            answer_args.answer_validator_path.as_ref(),
+                        )?;
+
+                    let exec_cmds = answer_validator_lang
+                        .get_program_execution_commands(answer_validator_path)?;
+
+                    if let Some(compile_cmd) = exec_cmds.compile_cmd() {
+                        run_compile_cmd(self.app, compile_cmd)
+                            .wrap_err("Failed to compile your answer validator")?;
+                    }
+
+                    Some(exec_cmds)
+                }
+            };
+
+            *initialiser_guard = Some(exec_cmds);
+        }
+
+        let exec_cmds_guard = self.get_answer_generator_exec_cmds()?;
+        let given_exec_cmds = exec_cmds_guard.as_ref().ok_or_else(|| {
+            eyre!("Failed to get answer validator run command. This is a bug, please report it!")
+        })?;
+
+        let exec_cmds = match given_exec_cmds {
+            Some(exec_cmds) => exec_cmds,
+            None => return Ok(io::Cursor::new(Vec::new())),
+        };
+
+        let answer_generator_output = run_with_input(self.app, exec_cmds.run_cmd(), &mut input)?;
 
         fail_if_output_is_not_success("answer", &answer_generator_output)?;
 
         Ok(io::Cursor::new(answer_generator_output.stdout))
+    }
+}
+
+impl<'a> GeneratorTestCase<'a> {
+    pub fn new(app: &'a App, solution: &'a Solution, args: &'a DebugArgs) -> Self {
+        Self {
+            app,
+            solution,
+            input_args: args.input_args(),
+            answer_args: args.answer_args(),
+            input_generator_exec_cmds: RwLock::new(None),
+            answer_generator_exec_cmds: RwLock::new(None),
+        }
+    }
+
+    fn should_check_answer(&self) -> bool {
+        self.answer_args.is_some()
+    }
+
+    fn get_input_generator_exec_cmds(
+        &self,
+    ) -> crate::Result<RwLockReadGuard<'_, Option<ExecuteProgramCommands>>> {
+        self.input_generator_exec_cmds
+            .read()
+            .map_err(|_| eyre!("Failed to lock input generator"))
+    }
+
+    fn has_initialised_input_generator(&self) -> crate::Result<bool> {
+        self.get_input_generator_exec_cmds()
+            .map(|cmd| cmd.is_some())
+    }
+
+    fn get_answer_generator_exec_cmds(
+        &self,
+    ) -> crate::Result<RwLockReadGuard<'_, Option<Option<ExecuteProgramCommands>>>> {
+        self.answer_generator_exec_cmds
+            .read()
+            .map_err(|_| eyre!("Failed to lock answer generator"))
+    }
+
+    fn has_initialised_answer_generator(&self) -> crate::Result<bool> {
+        self.get_answer_generator_exec_cmds()
+            .map(|cmd| cmd.is_some())
     }
 }
 
@@ -299,4 +364,20 @@ fn resolve_generator_file_to_use(
     }
 
     eyre::bail!("Multiple {name} generator files found. Specify which file to use.");
+}
+
+impl DebugArgs {
+    pub fn input_args(&self) -> &DebugInputArgs {
+        match &self.subcommand {
+            DebugSubcommand::Input(input_args) => input_args,
+            DebugSubcommand::Answer(answer_args) => &answer_args.input_args,
+        }
+    }
+
+    pub fn answer_args(&self) -> Option<&DebugAnswerArgs> {
+        match &self.subcommand {
+            DebugSubcommand::Input(_) => None,
+            DebugSubcommand::Answer(answer_args) => Some(answer_args),
+        }
+    }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,0 +1,306 @@
+use std::{
+    io::{self, Read},
+    path::{Path, PathBuf},
+    process,
+    time::{Duration, Instant},
+};
+
+use color_eyre::owo_colors::OwoColorize;
+use eyre::{bail, Context};
+
+use crate::{
+    cli::{DebugAnswerArgs, DebugArgs, DebugInputArgs, DebugSubcommand},
+    commands::test::{
+        print_test_case_error, run_compile_cmd, run_test, run_with_input, TestCaseError, FAILURE,
+        SUCCESS,
+    },
+    config::language::Language,
+    solution::{get_all_files_with_known_extension, get_debug_dir, Solution, SolutionOptions},
+    utils::{resolve_and_get_file_name, RunningAverager, TimedPrinter},
+    App,
+};
+
+use super::test::TestCaseIO;
+
+// TODO: Only compile generators and solution once
+pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
+    let input_args = match &args.subcommand {
+        DebugSubcommand::Input(input_args) => input_args,
+        DebugSubcommand::Answer(answer_args) => &answer_args.input_args,
+    };
+
+    let num_tests = input_args.num_tests;
+
+    let mut printer = TimedPrinter::new(Duration::from_millis(30));
+    let mut averager = RunningAverager::new();
+
+    for n in 1..=num_tests {
+        printer.flush_print(
+            format!("\r{} {n}/{num_tests}... ", "Running test".bright_cyan()),
+            n == num_tests,
+        )?;
+
+        let result = match &args.subcommand {
+            DebugSubcommand::Input(input_args) => run_with_generators(app, input_args, None),
+            DebugSubcommand::Answer(answer_args) => {
+                run_with_generators(app, input_args, Some(answer_args))
+            }
+        };
+
+        if result.is_err() {
+            println!("{FAILURE}\n");
+        }
+
+        let outcome = result?;
+        let execution_time = outcome
+            .as_ref()
+            .map_or_else(|e| e.execution_time, |v| v.execution_time);
+
+        averager.add_sample(execution_time.as_secs_f64());
+
+        if let Err(failure) = outcome {
+            println!("{FAILURE}\n");
+
+            print_test_case_error(&failure.test_case_error);
+
+            println!("{}:", "Input".bright_red());
+            println!("{}\n", failure.test_case_error.input().trim_end());
+
+            // TODO: Hide output if too large
+            // TODO: Write input/output to files
+            // TODO: Helpful message.. "you can copy this to your test directory with .in/.ans files"
+
+            return Ok(());
+        }
+    }
+
+    println!("{SUCCESS}\n");
+
+    let format_time = |secs: Option<f64>| {
+        secs.map(|secs| format!("{secs:.2}s"))
+            .unwrap_or_else(|| "N/A".to_string())
+    };
+
+    println!(
+        "{} all {num_tests} test cases. Running times: min {min_time}, max {max_time}, average {avg_time}.",
+        "Passed".bright_green(),
+        min_time = format_time(averager.min()),
+        max_time = format_time(averager.max()),
+        avg_time = format_time(averager.average()),
+    );
+
+    Ok(())
+}
+
+fn run_with_generators(
+    app: &App,
+    input_args: &DebugInputArgs,
+    answer_args: Option<&DebugAnswerArgs>,
+) -> crate::Result<Result<GeneratorSuccess, GeneratorError>> {
+    let solution = Solution::from_folder(
+        app,
+        &input_args.path,
+        SolutionOptions {
+            file_path: input_args.file.as_ref(),
+            lang: input_args.lang.as_ref(),
+        },
+    )?;
+
+    let debug_dir = get_debug_dir(&solution.dir);
+
+    eyre::ensure!(
+        get_debug_dir(&solution.dir).is_dir(),
+        "You don't have a debug folder. Create it at: {}",
+        debug_dir.display().underline()
+    );
+
+    let (input_generator_path, input_generator_lang) = resolve_generator_file_to_use(
+        app,
+        "input",
+        &debug_dir,
+        input_args.input_generator_path.as_ref(),
+    )?;
+
+    let input_gen_exec_cmds =
+        input_generator_lang.get_program_execution_commands(&input_generator_path)?;
+
+    if let Some(compile_cmd) = input_gen_exec_cmds.compile_cmd() {
+        run_compile_cmd(app, compile_cmd).wrap_err("Failed to compile your input generator")?;
+    }
+
+    let answer_validator_run_cmd = answer_args
+        .map(|answer_args| -> crate::Result<_> {
+            let (answer_validator_path, answer_validator_lang) = resolve_generator_file_to_use(
+                app,
+                "answer",
+                &debug_dir,
+                answer_args.answer_validator_path.as_ref(),
+            )?;
+
+            let answer_validator_exec_cmds =
+                answer_validator_lang.get_program_execution_commands(&answer_validator_path)?;
+
+            if let Some(compile_cmd) = answer_validator_exec_cmds.compile_cmd() {
+                run_compile_cmd(app, compile_cmd)
+                    .wrap_err("Failed to compile your answer validator")?;
+            }
+
+            Ok(answer_validator_exec_cmds.run_cmd().to_vec())
+        })
+        .transpose()?;
+
+    let test_case = TestCaseViaGenerator {
+        app,
+        input_generator_run_cmd: input_gen_exec_cmds.run_cmd(),
+        answer_generator_run_cmd: answer_validator_run_cmd.as_deref(),
+    };
+
+    let solution_exec_cmds = solution
+        .lang
+        .get_program_execution_commands(&solution.file)?;
+
+    if let Some(compile_cmd) = solution_exec_cmds.compile_cmd() {
+        run_compile_cmd(app, compile_cmd)?;
+    }
+
+    let start_time = Instant::now();
+    let test_result = run_test(app, &solution.lang.get_run_cmd(&solution.file)?, &test_case)?;
+    let execution_time = start_time.elapsed();
+
+    if let Err(test_case_error) = test_result {
+        let should_return_error = match test_case_error {
+            TestCaseError::RuntimeError { .. } => true,
+            TestCaseError::WrongAnswer { .. } if answer_args.is_some() => true,
+            _ => false,
+        };
+
+        if should_return_error {
+            return Ok(Err(GeneratorError {
+                test_case_error,
+                execution_time,
+            }));
+        }
+    }
+
+    Ok(Ok(GeneratorSuccess { execution_time }))
+}
+
+struct TestCaseViaGenerator<'a> {
+    app: &'a App,
+    input_generator_run_cmd: &'a [String],
+    answer_generator_run_cmd: Option<&'a [String]>,
+}
+
+impl TestCaseIO for TestCaseViaGenerator<'_> {
+    type Input<'a> = io::Cursor<Vec<u8>> where Self: 'a;
+    type Answer<'a> = io::Cursor<Vec<u8>> where Self: 'a;
+
+    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>> {
+        let input_generator_output =
+            run_with_input(self.app, &self.input_generator_run_cmd, &mut io::empty())?;
+
+        fail_if_output_is_not_success("input", &input_generator_output)?;
+
+        Ok(io::Cursor::new(input_generator_output.stdout))
+    }
+
+    fn answer<'a, R: Read>(&'a self, input: Option<R>) -> crate::Result<Self::Answer<'a>> {
+        let answer_generator_run_cmd = match self.answer_generator_run_cmd {
+            Some(answer_generator_run_cmd) => answer_generator_run_cmd,
+            None => return Ok(io::Cursor::new(Vec::new())),
+        };
+
+        let mut input: Box<dyn Read> = match input {
+            Some(input) => Box::new(input),
+            None => Box::new(io::empty()),
+        };
+
+        let answer_generator_output =
+            run_with_input(self.app, answer_generator_run_cmd, &mut input)?;
+
+        fail_if_output_is_not_success("answer", &answer_generator_output)?;
+
+        Ok(io::Cursor::new(answer_generator_output.stdout))
+    }
+}
+
+fn fail_if_output_is_not_success(name: &str, output: &process::Output) -> crate::Result<()> {
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    bail!(
+        indoc::indoc! {"
+            Your {name} generator exited with a non-zero exit code ({status}).
+
+            {label}:
+            {stdout}
+            {stderr}\
+        "},
+        label = "Generator output".bright_red(),
+        name = name,
+        status = output.status,
+        stdout = stdout.trim_end(),
+        stderr = stderr.trim_end()
+    );
+}
+
+#[derive(Debug)]
+struct GeneratorError {
+    test_case_error: TestCaseError,
+    execution_time: Duration,
+}
+
+#[derive(Debug)]
+struct GeneratorSuccess {
+    execution_time: Duration,
+}
+
+fn resolve_generator_file_to_use(
+    app: &App,
+    name: impl AsRef<str>,
+    debug_dir: impl AsRef<Path>,
+    file_path: Option<impl AsRef<Path>>,
+) -> crate::Result<(PathBuf, &Language)> {
+    let name = name.as_ref();
+
+    if let Some(file_path) = file_path {
+        let file_path = file_path.as_ref();
+
+        eyre::ensure!(
+            file_path.is_file(),
+            "The {name} generator file path does not point to a file: {}",
+            file_path.display().underline()
+        );
+
+        return Ok((
+            file_path.to_path_buf(),
+            app.config.try_lang_from_file(&file_path)?,
+        ));
+    }
+
+    let debug_dir = debug_dir.as_ref();
+    let options = get_all_files_with_known_extension(app, debug_dir)?
+        .into_iter()
+        .filter(|path| {
+            resolve_and_get_file_name(&path)
+                .map(|file_name| file_name.contains(name))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    eyre::ensure!(
+        !options.is_empty(),
+        "No {name} generator file found in the debug folder: {}. See the help message for how to create one.",
+        debug_dir.display().underline()
+    );
+
+    if let [file] = options.as_slice() {
+        return Ok((file.clone(), app.config.try_lang_from_file(&file)?));
+    }
+
+    eyre::bail!("Multiple {name} generator files found. Specify which file to use.");
+}

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -416,11 +416,10 @@ fn write_failure_to_files(solution: &Solution, failure: &GeneratorError) -> crat
             println!("\nTo use these as part of normal `kitty test` runs, move the .in/.ans files to the test folder of your solution.")
         }
         TestCaseError::RuntimeError { stdout, stderr, .. } => {
-            let combined: String = [stdout.clone(), stderr.clone()].join(" ");
             write_file(
                 "your solution's output",
                 &format!("{file_basename}.output"),
-                &combined,
+                &[stdout.clone(), stderr.clone()].join("\n"),
             )?;
         }
     }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -118,7 +118,7 @@ fn run_with_generators(
     )?;
 
     let input_gen_exec_cmds =
-        input_generator_lang.get_program_execution_commands(&input_generator_path)?;
+        input_generator_lang.get_program_execution_commands(input_generator_path)?;
 
     if let Some(compile_cmd) = input_gen_exec_cmds.compile_cmd() {
         run_compile_cmd(app, compile_cmd).wrap_err("Failed to compile your input generator")?;
@@ -134,7 +134,7 @@ fn run_with_generators(
             )?;
 
             let answer_validator_exec_cmds =
-                answer_validator_lang.get_program_execution_commands(&answer_validator_path)?;
+                answer_validator_lang.get_program_execution_commands(answer_validator_path)?;
 
             if let Some(compile_cmd) = answer_validator_exec_cmds.compile_cmd() {
                 run_compile_cmd(app, compile_cmd)
@@ -191,16 +191,16 @@ impl TestCaseIO for GeneratorTestCase<'_> {
     type Input<'a> = io::Cursor<Vec<u8>> where Self: 'a;
     type Answer<'a> = io::Cursor<Vec<u8>> where Self: 'a;
 
-    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>> {
+    fn input(&self) -> crate::Result<Self::Input<'_>> {
         let input_generator_output =
-            run_with_input(self.app, &self.input_generator_run_cmd, &mut io::empty())?;
+            run_with_input(self.app, self.input_generator_run_cmd, &mut io::empty())?;
 
         fail_if_output_is_not_success("input", &input_generator_output)?;
 
         Ok(io::Cursor::new(input_generator_output.stdout))
     }
 
-    fn answer<'a, R: Read>(&'a self, input: Option<R>) -> crate::Result<Self::Answer<'a>> {
+    fn answer<R: Read>(&self, input: Option<R>) -> crate::Result<Self::Answer<'_>> {
         let answer_generator_run_cmd = match self.answer_generator_run_cmd {
             Some(answer_generator_run_cmd) => answer_generator_run_cmd,
             None => return Ok(io::Cursor::new(Vec::new())),
@@ -274,7 +274,7 @@ fn resolve_generator_file_to_use(
 
         return Ok((
             file_path.to_path_buf(),
-            app.config.try_lang_from_file(&file_path)?,
+            app.config.try_lang_from_file(file_path)?,
         ));
     }
 
@@ -282,7 +282,7 @@ fn resolve_generator_file_to_use(
     let options = get_all_files_with_known_extension(app, debug_dir)?
         .into_iter()
         .filter(|path| {
-            resolve_and_get_file_name(&path)
+            resolve_and_get_file_name(path)
                 .map(|file_name| file_name.contains(name))
                 .unwrap_or(false)
         })
@@ -295,7 +295,7 @@ fn resolve_generator_file_to_use(
     );
 
     if let [file] = options.as_slice() {
-        return Ok((file.clone(), app.config.try_lang_from_file(&file)?));
+        return Ok((file.clone(), app.config.try_lang_from_file(file)?));
     }
 
     eyre::bail!("Multiple {name} generator files found. Specify which file to use.");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,7 +4,7 @@ mod get;
 mod langs;
 mod open;
 mod submit;
-pub mod test;
+mod test;
 mod update;
 
 pub use config::config;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,12 +1,14 @@
 mod config;
+mod debug;
 mod get;
 mod langs;
 mod open;
 mod submit;
-mod test;
+pub mod test;
 mod update;
 
 pub use config::config;
+pub use debug::debug;
 pub use get::get;
 pub use langs::langs;
 pub use open::open;

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -186,13 +186,13 @@ pub trait TestCaseIO {
         R: Read;
 }
 
-pub struct TestCaseViaFile {
+pub struct FileTestCase {
     pub name: String,
     pub input_file: PathBuf,
     pub answer_file: PathBuf,
 }
 
-impl TestCaseIO for TestCaseViaFile {
+impl TestCaseIO for FileTestCase {
     type Input<'a> = File;
     type Answer<'a> = File;
 

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,7 +1,6 @@
 use std::{
     io::{stdout, Write},
     path::Path,
-    time::Instant,
 };
 
 use colored::Colorize;
@@ -77,14 +76,14 @@ fn run_tests(
         print!("test {} ... ", test_case.name);
         stdout().flush().wrap_err("Failed to flush output")?;
 
-        let start_time = Instant::now();
         let outcome = run_test(app, execution_commands.run_cmd(), test_case)?;
-        let elapsed_time = start_time.elapsed();
 
         print!("{}", if outcome.is_ok() { SUCCESS } else { FAILURE });
 
         if args.time {
-            print!(" in {:.2}s", elapsed_time.as_secs_f64());
+            if let Ok(test_info) = &outcome {
+                print!(" in {:.2}s", test_info.running_time.as_secs_f64());
+            }
         }
 
         if outcome.is_err() {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,13 +1,11 @@
 use std::{
-    fs::File,
-    io::{self, stdout, Read, Write},
-    path::{Path, PathBuf},
-    process::{self, Command, Stdio},
+    io::{stdout, Write},
+    path::Path,
     time::Instant,
 };
 
 use colored::Colorize;
-use eyre::{bail, Context};
+use eyre::Context;
 use notify::{event::ModifyKind, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use regex::Regex;
 
@@ -15,6 +13,7 @@ use crate::{
     cli::TestArgs,
     config::language::ExecuteProgramCommands,
     solution::{get_test_cases, get_test_dir, Solution, SolutionOptions},
+    test_io::{run_compile_cmd, run_test},
     utils::prompt_bool,
     App,
 };
@@ -95,7 +94,7 @@ fn run_tests(
         println!();
 
         if let Err(test_case_error) = outcome {
-            print_test_case_error(&test_case_error);
+            test_case_error.print();
         }
     }
 
@@ -111,219 +110,6 @@ fn run_tests(
     );
 
     Ok(())
-}
-
-pub fn run_test<'a, T: TestCaseIO + 'a>(
-    app: &App,
-    run_cmd: &[String],
-    test_case: &'a T,
-) -> crate::Result<TestCaseResult>
-where
-    <T as TestCaseIO>::Input<'a>: Read,
-    <T as TestCaseIO>::Answer<'a>: Read,
-{
-    let input = test_case.input()?;
-    let input = io::read_to_string(input).wrap_err("Failed to load input")?;
-
-    let expected_answer = test_case.answer(Some(input.as_bytes()))?;
-    let expected_answer =
-        io::read_to_string(expected_answer).wrap_err("Failed to load expected answer")?;
-
-    let output = run_with_input(app, run_cmd, &mut input.as_bytes())?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    if !output.status.success() {
-        return Ok(Err(TestCaseError::RuntimeError {
-            input,
-            stdout,
-            stderr,
-        }));
-    }
-
-    if !are_equal_after_normalisation(&stdout, &expected_answer) {
-        return Ok(Err(TestCaseError::WrongAnswer {
-            input,
-            expected: expected_answer.trim_end().to_string(),
-            actual: stdout.trim_end().to_string(),
-        }));
-    }
-
-    Ok(Ok(()))
-}
-
-pub fn print_test_case_error(err: &TestCaseError) {
-    match err {
-        TestCaseError::WrongAnswer {
-            expected, actual, ..
-        } => {
-            println!("{}", "Expected:".underline());
-            println!("{}\n", expected.trim_end());
-            println!("{}", "Actual:".underline());
-            println!("{}\n", actual.trim_end());
-        }
-        TestCaseError::RuntimeError { stdout, stderr, .. } => {
-            println!("{}:", "Runtime error".bright_red());
-            println!("{}", stdout.trim_end());
-            println!("{}\n", stderr.trim_end());
-        }
-    }
-}
-
-pub trait TestCaseIO {
-    type Input<'a>
-    where
-        Self: 'a;
-
-    type Answer<'a>
-    where
-        Self: 'a;
-
-    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>>;
-    fn answer<'a, R>(&'a self, input: Option<R>) -> crate::Result<Self::Answer<'a>>
-    where
-        R: Read;
-}
-
-pub struct FileTestCase {
-    pub name: String,
-    pub input_file: PathBuf,
-    pub answer_file: PathBuf,
-}
-
-impl TestCaseIO for FileTestCase {
-    type Input<'a> = File;
-    type Answer<'a> = File;
-
-    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>> {
-        File::open(&self.input_file).wrap_err("Failed to open input file")
-    }
-
-    fn answer<'a, R: Read>(&'a self, _input: Option<R>) -> crate::Result<Self::Answer<'a>> {
-        File::open(&self.answer_file).wrap_err("Failed to open answer file")
-    }
-}
-
-pub type TestCaseResult = Result<(), TestCaseError>;
-
-#[derive(Debug)]
-pub enum TestCaseError {
-    WrongAnswer {
-        input: String,
-        expected: String,
-        actual: String,
-    },
-    RuntimeError {
-        input: String,
-        stdout: String,
-        stderr: String,
-    },
-}
-
-impl TestCaseError {
-    pub fn input(&self) -> &str {
-        match self {
-            TestCaseError::RuntimeError { ref input, .. } => input,
-            TestCaseError::WrongAnswer { ref input, .. } => input,
-        }
-    }
-}
-
-pub fn run_with_input(
-    app: &App,
-    run_cmd: &[String],
-    input: &mut impl Read,
-) -> crate::Result<process::Output> {
-    let (run_program, run_program_args) = run_cmd
-        .split_first()
-        .ok_or_else(|| eyre::eyre!("Run command is empty"))?;
-
-    if app.args.verbose {
-        eprintln!(
-            "Run command:\n\n   {}\n",
-            shlex::join(run_cmd.iter().map(String::as_str))
-        );
-    }
-
-    let mut child = Command::new(run_program)
-        .args(run_program_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|err| match err.kind() {
-            io::ErrorKind::NotFound => {
-                eyre::eyre!("Failed to find the runner program '{}'", run_program)
-            }
-            _ => eyre::eyre!("Failed to run the runner program: {}", err),
-        })?;
-
-    let mut child_stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| eyre::eyre!("Failed to capture stdin of your solution"))?;
-
-    io::copy(input, &mut child_stdin)
-        .wrap_err("Failed to write test case input to your solution")?;
-
-    // Manually drop stdin to ensure that EOF is sent. If this is not done, the
-    // child process might not terminate if it reads until EOF.
-    drop(child_stdin);
-
-    let output = child
-        .wait_with_output()
-        .wrap_err("Failed to run the solution")?;
-
-    Ok(output)
-}
-
-pub fn run_compile_cmd(app: &App, compile_cmd: &[String]) -> crate::Result<()> {
-    let (compiler_program, compiler_args) = compile_cmd
-        .split_first()
-        .ok_or_else(|| eyre::eyre!("Compile command is empty"))?;
-
-    if app.args.verbose {
-        eprintln!(
-            "Compiler command:\n\n   {}\n",
-            shlex::join(compile_cmd.iter().map(String::as_str))
-        );
-    }
-
-    let output = Command::new(compiler_program)
-        .args(compiler_args)
-        .output()
-        .map_err(|err| match err.kind() {
-            io::ErrorKind::NotFound => {
-                eyre::eyre!("Failed to find the compiler program '{}'", compiler_program)
-            }
-            _ => eyre::eyre!("Failed to run the compiler program: {}", err),
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        eprintln!("{}:", "Compilation error".bright_red());
-        eprintln!("{stdout}");
-        eprintln!("{stderr}");
-
-        bail!("Failed to compile program ({})", output.status);
-    }
-
-    Ok(())
-}
-
-fn are_equal_after_normalisation(a: &str, b: &str) -> bool {
-    fn normalise(s: &str) -> String {
-        s.trim_end()
-            .lines()
-            .map(str::trim_end)
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    normalise(a) == normalise(b)
 }
 
 async fn fetch_tests_if_needed(

--- a/src/config/language.rs
+++ b/src/config/language.rs
@@ -66,6 +66,7 @@ impl fmt::Display for Language {
     }
 }
 
+#[derive(Debug)]
 pub struct ExecuteProgramCommands {
     run_cmd: Vec<String>,
     compile_cmd: Option<Vec<String>>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -99,6 +99,11 @@ impl Config {
         Ok(self.lang_from_file_ext(ext))
     }
 
+    pub fn try_lang_from_file(&self, file: impl AsRef<Path>) -> crate::Result<&Language> {
+        self.lang_from_file(file)?
+            .ok_or_else(|| eyre::eyre!("Couldn't recognise the language from the file extension"))
+    }
+
     pub fn default_language(&self) -> Option<&Language> {
         self.default_language
             .as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ async fn try_run(args: cli::KittyArgs) -> crate::Result<()> {
 
     match &app.args.subcommand {
         Config(args) => commands::config(&app, args).await,
+        Debug(args) => commands::debug(&app, args).await,
         Get(args) => commands::get(&app, args).await,
         Langs => commands::langs(&app).await,
         Open(args) => commands::open(&app, args).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod config;
 mod kattis_client;
 mod problem;
 mod solution;
+mod test_io;
 mod utils;
 
 pub type Result<T> = eyre::Result<T>;

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -57,6 +57,10 @@ impl<'a> Solution<'a> {
             lang: solution_lang,
         })
     }
+
+    pub fn debug_dir(&self) -> PathBuf {
+        self.dir.join("debug")
+    }
 }
 
 #[derive(Debug)]
@@ -67,10 +71,6 @@ pub struct SolutionOptions<'a> {
 
 pub fn get_test_dir(solution_dir: impl AsRef<Path>) -> PathBuf {
     solution_dir.as_ref().join("test")
-}
-
-pub fn get_debug_dir(solution_dir: impl AsRef<Path>) -> PathBuf {
-    solution_dir.as_ref().join("debug")
 }
 
 fn resolve_solution_file_to_use(

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -9,6 +9,7 @@ use color_eyre::owo_colors::OwoColorize;
 use eyre::Context;
 
 use crate::{
+    commands::test::TestCaseViaFile,
     config::language::Language,
     utils::{get_full_path, resolve_and_get_file_name},
     App,
@@ -68,6 +69,10 @@ pub fn get_test_dir(solution_dir: impl AsRef<Path>) -> PathBuf {
     solution_dir.as_ref().join("test")
 }
 
+pub fn get_debug_dir(solution_dir: impl AsRef<Path>) -> PathBuf {
+    solution_dir.as_ref().join("debug")
+}
+
 fn resolve_solution_file_to_use(
     app: &App,
     solution_dir: impl AsRef<Path>,
@@ -101,7 +106,7 @@ fn resolve_solution_file_to_use(
     eyre::bail!("Multiple solution files found. Specify which file to use with the --file option.");
 }
 
-fn get_all_files_with_known_extension(
+pub fn get_all_files_with_known_extension(
     app: &App,
     folder: impl AsRef<Path>,
 ) -> crate::Result<Vec<PathBuf>> {
@@ -122,13 +127,7 @@ fn get_all_files_with_known_extension(
     Ok(options)
 }
 
-pub struct TestCase {
-    pub name: String,
-    pub input_file: PathBuf,
-    pub answer_file: PathBuf,
-}
-
-pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<TestCase>> {
+pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<TestCaseViaFile>> {
     let test_dir_files = get_test_dir(solution_dir)
         .read_dir()
         .wrap_err("Failed to read test case folder")?
@@ -166,11 +165,13 @@ pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<TestC
     let test_files = input_files
         .into_iter()
         .filter_map(|(name, input_file)| {
-            answer_files.remove(&name).map(|answer_file| TestCase {
-                name,
-                input_file,
-                answer_file,
-            })
+            answer_files
+                .remove(&name)
+                .map(|answer_file| TestCaseViaFile {
+                    name,
+                    input_file,
+                    answer_file,
+                })
         })
         .collect();
 

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -61,6 +61,10 @@ impl<'a> Solution<'a> {
     pub fn debug_dir(&self) -> PathBuf {
         self.dir.join("debug")
     }
+
+    pub fn debug_save_dir(&self) -> PathBuf {
+        self.debug_dir().join("saved")
+    }
 }
 
 #[derive(Debug)]

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -9,8 +9,8 @@ use color_eyre::owo_colors::OwoColorize;
 use eyre::Context;
 
 use crate::{
-    commands::test::FileTestCase,
     config::language::Language,
+    test_io::FileTestCase,
     utils::{get_full_path, resolve_and_get_file_name},
     App,
 };

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -9,7 +9,7 @@ use color_eyre::owo_colors::OwoColorize;
 use eyre::Context;
 
 use crate::{
-    commands::test::TestCaseViaFile,
+    commands::test::FileTestCase,
     config::language::Language,
     utils::{get_full_path, resolve_and_get_file_name},
     App,
@@ -127,7 +127,7 @@ pub fn get_all_files_with_known_extension(
     Ok(options)
 }
 
-pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<TestCaseViaFile>> {
+pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<FileTestCase>> {
     let test_dir_files = get_test_dir(solution_dir)
         .read_dir()
         .wrap_err("Failed to read test case folder")?
@@ -165,13 +165,11 @@ pub fn get_test_cases(solution_dir: impl AsRef<Path>) -> crate::Result<Vec<TestC
     let test_files = input_files
         .into_iter()
         .filter_map(|(name, input_file)| {
-            answer_files
-                .remove(&name)
-                .map(|answer_file| TestCaseViaFile {
-                    name,
-                    input_file,
-                    answer_file,
-                })
+            answer_files.remove(&name).map(|answer_file| FileTestCase {
+                name,
+                input_file,
+                answer_file,
+            })
         })
         .collect();
 

--- a/src/test_io.rs
+++ b/src/test_io.rs
@@ -19,8 +19,8 @@ pub trait TestCaseIO {
     where
         Self: 'a;
 
-    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>>;
-    fn answer<'a, R>(&'a self, input: Option<R>) -> crate::Result<Self::Answer<'a>>
+    fn input(&self) -> crate::Result<Self::Input<'_>>;
+    fn answer<R>(&self, input: Option<R>) -> crate::Result<Self::Answer<'_>>
     where
         R: Read;
 }
@@ -173,11 +173,11 @@ impl TestCaseIO for FileTestCase {
     type Input<'a> = File;
     type Answer<'a> = File;
 
-    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>> {
+    fn input(&self) -> crate::Result<Self::Input<'_>> {
         File::open(&self.input_file).wrap_err("Failed to open input file")
     }
 
-    fn answer<'a, R: Read>(&'a self, _input: Option<R>) -> crate::Result<Self::Answer<'a>> {
+    fn answer<R: Read>(&self, _input: Option<R>) -> crate::Result<Self::Answer<'_>> {
         File::open(&self.answer_file).wrap_err("Failed to open answer file")
     }
 }

--- a/src/test_io.rs
+++ b/src/test_io.rs
@@ -1,0 +1,224 @@
+use std::{
+    fs::File,
+    io::{self, Read},
+    path::PathBuf,
+    process::{self, Command, Stdio},
+};
+
+use colored::Colorize;
+use eyre::{bail, Context};
+
+use crate::App;
+
+pub trait TestCaseIO {
+    type Input<'a>
+    where
+        Self: 'a;
+
+    type Answer<'a>
+    where
+        Self: 'a;
+
+    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>>;
+    fn answer<'a, R>(&'a self, input: Option<R>) -> crate::Result<Self::Answer<'a>>
+    where
+        R: Read;
+}
+
+pub type TestCaseResult = Result<(), TestCaseError>;
+
+pub fn run_test<'a, T: TestCaseIO + 'a>(
+    app: &App,
+    run_cmd: &[String],
+    test_case: &'a T,
+) -> crate::Result<TestCaseResult>
+where
+    <T as TestCaseIO>::Input<'a>: Read,
+    <T as TestCaseIO>::Answer<'a>: Read,
+{
+    let input = test_case.input()?;
+    let input = io::read_to_string(input).wrap_err("Failed to load input")?;
+
+    let expected_answer = test_case.answer(Some(input.as_bytes()))?;
+    let expected_answer =
+        io::read_to_string(expected_answer).wrap_err("Failed to load expected answer")?;
+
+    let output = run_with_input(app, run_cmd, &mut input.as_bytes())?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        return Ok(Err(TestCaseError::RuntimeError {
+            input,
+            stdout,
+            stderr,
+        }));
+    }
+
+    if !are_equal_after_normalisation(&stdout, &expected_answer) {
+        return Ok(Err(TestCaseError::WrongAnswer {
+            input,
+            expected: expected_answer.trim_end().to_string(),
+            actual: stdout.trim_end().to_string(),
+        }));
+    }
+
+    Ok(Ok(()))
+}
+
+pub fn run_with_input(
+    app: &App,
+    run_cmd: &[String],
+    input: &mut impl Read,
+) -> crate::Result<process::Output> {
+    let (run_program, run_program_args) = run_cmd
+        .split_first()
+        .ok_or_else(|| eyre::eyre!("Run command is empty"))?;
+
+    if app.args.verbose {
+        eprintln!(
+            "Run command:\n\n   {}\n",
+            shlex::join(run_cmd.iter().map(String::as_str))
+        );
+    }
+
+    let mut child = Command::new(run_program)
+        .args(run_program_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| match err.kind() {
+            io::ErrorKind::NotFound => {
+                eyre::eyre!("Failed to find the runner program '{}'", run_program)
+            }
+            _ => eyre::eyre!("Failed to run the runner program: {}", err),
+        })?;
+
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| eyre::eyre!("Failed to capture stdin of your solution"))?;
+
+    io::copy(input, &mut child_stdin)
+        .wrap_err("Failed to write test case input to your solution")?;
+
+    // Manually drop stdin to ensure that EOF is sent. If this is not done, the
+    // child process might not terminate if it reads until EOF.
+    drop(child_stdin);
+
+    let output = child
+        .wait_with_output()
+        .wrap_err("Failed to run the solution")?;
+
+    Ok(output)
+}
+
+pub fn run_compile_cmd(app: &App, compile_cmd: &[String]) -> crate::Result<()> {
+    let (compiler_program, compiler_args) = compile_cmd
+        .split_first()
+        .ok_or_else(|| eyre::eyre!("Compile command is empty"))?;
+
+    if app.args.verbose {
+        eprintln!(
+            "Compiler command:\n\n   {}\n",
+            shlex::join(compile_cmd.iter().map(String::as_str))
+        );
+    }
+
+    let output = Command::new(compiler_program)
+        .args(compiler_args)
+        .output()
+        .map_err(|err| match err.kind() {
+            io::ErrorKind::NotFound => {
+                eyre::eyre!("Failed to find the compiler program '{}'", compiler_program)
+            }
+            _ => eyre::eyre!("Failed to run the compiler program: {}", err),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        eprintln!("{}:", "Compilation error".bright_red());
+        eprintln!("{stdout}");
+        eprintln!("{stderr}");
+
+        bail!("Failed to compile program ({})", output.status);
+    }
+
+    Ok(())
+}
+
+pub fn are_equal_after_normalisation(a: &str, b: &str) -> bool {
+    fn normalise(s: &str) -> String {
+        s.trim_end()
+            .lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    normalise(a) == normalise(b)
+}
+
+pub struct FileTestCase {
+    pub name: String,
+    pub input_file: PathBuf,
+    pub answer_file: PathBuf,
+}
+
+impl TestCaseIO for FileTestCase {
+    type Input<'a> = File;
+    type Answer<'a> = File;
+
+    fn input<'a>(&'a self) -> crate::Result<Self::Input<'a>> {
+        File::open(&self.input_file).wrap_err("Failed to open input file")
+    }
+
+    fn answer<'a, R: Read>(&'a self, _input: Option<R>) -> crate::Result<Self::Answer<'a>> {
+        File::open(&self.answer_file).wrap_err("Failed to open answer file")
+    }
+}
+
+#[derive(Debug)]
+pub enum TestCaseError {
+    WrongAnswer {
+        input: String,
+        expected: String,
+        actual: String,
+    },
+    RuntimeError {
+        input: String,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+impl TestCaseError {
+    pub fn input(&self) -> &str {
+        match self {
+            TestCaseError::RuntimeError { ref input, .. } => input,
+            TestCaseError::WrongAnswer { ref input, .. } => input,
+        }
+    }
+
+    pub fn print(&self) {
+        match self {
+            TestCaseError::WrongAnswer {
+                expected, actual, ..
+            } => {
+                println!("{}", "Expected:".underline());
+                println!("{}\n", expected.trim_end());
+                println!("{}", "Actual:".underline());
+                println!("{}\n", actual.trim_end());
+            }
+            TestCaseError::RuntimeError { stdout, stderr, .. } => {
+                println!("{}:", "Runtime error".bright_red());
+                println!("{}", stdout.trim_end());
+                println!("{}\n", stderr.trim_end());
+            }
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
 use std::{
     env,
-    io::{self, Write},
+    io::{self, stdout, Write},
     path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
 use eyre::Context;
@@ -41,4 +42,73 @@ pub fn prompt_bool(question: &str) -> crate::Result<bool> {
         .wrap_err("failed to read input")?;
 
     Ok(input.trim().to_lowercase() == "y")
+}
+
+pub struct TimedPrinter {
+    last_print_time: Option<Instant>,
+    interval: Duration,
+}
+
+impl TimedPrinter {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            last_print_time: None,
+            interval,
+        }
+    }
+
+    pub fn flush_print(&mut self, msg: impl AsRef<str>, force: bool) -> crate::Result<()> {
+        match self.last_print_time {
+            Some(last_print_time) if last_print_time.elapsed() < self.interval && !force => {}
+            _ => {
+                self.last_print_time = Some(Instant::now());
+                print!("{}", msg.as_ref());
+                stdout().flush().wrap_err("Failed to flush output")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct RunningAverager {
+    num_samples: usize,
+    average: Option<f64>,
+    min: Option<f64>,
+    max: Option<f64>,
+}
+
+impl RunningAverager {
+    pub fn new() -> Self {
+        Self {
+            num_samples: 0,
+            average: None,
+            min: None,
+            max: None,
+        }
+    }
+
+    pub fn add_sample(&mut self, sample: f64) {
+        self.num_samples += 1;
+
+        self.average = self
+            .average
+            .map(|average| average + (sample - average) / self.num_samples as f64)
+            .or(Some(sample));
+
+        self.min = self.min.map(|min| min.min(sample)).or(Some(sample));
+        self.max = self.max.map(|max| max.max(sample)).or(Some(sample));
+    }
+
+    pub fn average(&self) -> Option<f64> {
+        self.average
+    }
+
+    pub fn min(&self) -> Option<f64> {
+        self.min
+    }
+
+    pub fn max(&self) -> Option<f64> {
+        self.max
+    }
 }

--- a/tests/kitty-cli/Dockerfile
+++ b/tests/kitty-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67-slim
+FROM rust:1.72-slim
 
 RUN apt update && apt install -y libssl-dev pkg-config
 RUN apt install -y python3 python-is-python3

--- a/tests/kitty-cli/data/generators/quadrant-buggy-input-generator.py
+++ b/tests/kitty-cli/data/generators/quadrant-buggy-input-generator.py
@@ -1,0 +1,3 @@
+print(42)
+raise Exception("Buggy input generator")
+print(420)

--- a/tests/kitty-cli/data/generators/quadrant-input-generator.py
+++ b/tests/kitty-cli/data/generators/quadrant-input-generator.py
@@ -1,0 +1,12 @@
+import random
+
+
+def pick_random_nonzero_int():
+    x = 0
+    while x == 0:
+        x = random.randint(-1000, 1000)
+    return x
+
+
+print(pick_random_nonzero_int())
+print(pick_random_nonzero_int())

--- a/tests/kitty-cli/data/quadrant-runtime-error.py
+++ b/tests/kitty-cli/data/quadrant-runtime-error.py
@@ -2,11 +2,11 @@ from sys import stdin
 
 x, y = int(next(stdin)), int(next(stdin))
 
-if x < 0 and y < 0:
-    print(1)
-if x < 0 and y > 0:
-    print(2)
 if x > 0 and y > 0:
     raise Exception("I don't know what quadrant this is in!")
+if x < 0 and y > 0:
+    print(2)
+if x < 0 and y < 0:
+    print(3)
 if x > 0 and y < 0:
     print(4)

--- a/tests/kitty-cli/debug/answer.rs
+++ b/tests/kitty-cli/debug/answer.rs
@@ -1,0 +1,199 @@
+use futures_util::FutureExt;
+
+use crate::helpers::{
+    contains, make_standard_setup, matches_regex, run_with_sandbox,
+    OutputSource::{StdErr, StdOut},
+};
+
+#[test]
+fn answer_generator_finishes_on_valid_solution() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+            env.copy(
+                "./tests/kitty-cli/data/quadrant.c",
+                "/work/quadrant/debug/answer.c",
+            );
+
+            env.run("cd quadrant && kitty debug answer")
+                .await
+                .assert(StdOut, contains("Running test 1/100..."))
+                .assert(
+                    StdOut,
+                    matches_regex(indoc::indoc! {r#"
+                        Running test 100/100... ✅
+
+                        Passed all 100 test cases. Running times: min \d+.\d+s, max \d+.\d+s, average \d+.\d+s.
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn missing_answer_generator_shows_helpful_message() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+
+            env.run("cd quadrant && kitty debug answer")
+                .await
+                .assert(
+                    StdErr,
+                    contains("Error: No answer generator file found in the debug folder: /work/quadrant/./debug. See the help message for how to create one."),
+                );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn answer_validator_wrong_answer_shows_actual_output_and_input_parameters() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.copy(
+                "./tests/kitty-cli/data/quadrant-wrong-answer.py",
+                "/work/quadrant/quadrant.py",
+            );
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+            env.copy(
+                "./tests/kitty-cli/data/quadrant.c",
+                "/work/quadrant/debug/answer.c",
+            );
+
+            env.run("cd quadrant && kitty debug answer").await.assert(
+                StdOut,
+                matches_regex(indoc::indoc! {r#"
+                    Running test \d+/100... ❌
+
+                    Expected:
+                    \d
+
+                    Actual:
+                    \d
+
+                    Input:
+                    -?\d+
+                    -?\d+
+
+                    Saving input to \d+-wrong-answer.in
+                    Saving expected answer to \d+-wrong-answer.ans
+                    Saving your answer to \d+-wrong-answer.output
+
+                    To use these as part of normal `kitty test` runs, move the .in/.ans files to the test folder of your solution.
+
+                    The saved files can be found in /work/quadrant/./debug/saved
+                "#}),
+            );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn answer_validator_runtime_error_shows_error_and_input_parameters() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.copy(
+                "./tests/kitty-cli/data/quadrant-runtime-error.py",
+                "/work/quadrant/quadrant.py",
+            );
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+            env.copy(
+                "./tests/kitty-cli/data/quadrant.c",
+                "/work/quadrant/debug/answer.c",
+            );
+
+            env.run("cd quadrant && kitty debug answer").await.assert(
+                StdOut,
+                matches_regex(indoc::indoc! {r#"
+                    Running test \d+/100... ❌
+
+                    Runtime error:
+
+                    Traceback (most recent call last):
+                      File "/work/quadrant/./quadrant.py", line 6, in <module>
+                        raise Exception("I don't know what quadrant this is in!")
+                    Exception: I don't know what quadrant this is in!
+
+                    Input:
+                    -?\d+
+                    -?\d+
+
+                    Saving input to \d+-runtime-error.in
+                    Saving your solution's output to \d+-runtime-error.output
+
+                    The saved files can be found in /work/quadrant/./debug/saved
+                "#}),
+            );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn buggy_answer_validator_shows_runtime_error() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+            env.copy(
+                "./tests/kitty-cli/data/quadrant-runtime-error.py",
+                "/work/quadrant/debug/answer.py",
+            );
+
+            env.run("cd quadrant && kitty debug answer")
+                .await
+                .assert(StdOut, matches_regex(r"Running test \d+/100... ❌"))
+                .assert(
+                    StdErr,
+                    contains(indoc::indoc! {r#"
+                        Error: Your answer generator exited with a non-zero exit code (exit status: 1).
+
+                        Generator output:
+
+                        Traceback (most recent call last):
+                          File "/work/quadrant/./debug/answer.py", line 6, in <module>
+                            raise Exception("I don't know what quadrant this is in!")
+                        Exception: I don't know what quadrant this is in!
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}

--- a/tests/kitty-cli/debug/input.rs
+++ b/tests/kitty-cli/debug/input.rs
@@ -1,7 +1,7 @@
 use futures_util::FutureExt;
 
 use crate::helpers::{
-    contains, make_standard_setup, run_with_sandbox,
+    contains, make_standard_setup, matches_regex, run_with_sandbox,
     OutputSource::{StdErr, StdOut},
 };
 
@@ -51,28 +51,28 @@ fn input_generator_shows_error_if_solution_crashes() {
                 "/work/quadrant/debug/input.py",
             );
 
-            env.run("cd quadrant && kitty debug input")
-                .await
-                .assert(StdOut, contains("Running test 1/100..."))
-                .assert(StdOut, contains(""))
-                .assert(
-                    StdOut,
-                    contains(indoc::indoc! {r#"
-                        /100... ❌
+            env.run("cd quadrant && kitty debug input").await.assert(
+                StdOut,
+                matches_regex(indoc::indoc! {r#"
+                    Running test \d+/\d+... ❌
 
-                        Runtime error:
+                    Runtime error:
 
-                        Traceback (most recent call last):
-                          File "/work/quadrant/./quadrant.py", line 10, in <module>
-                            raise Exception("I don't know what quadrant this is in!")
-                        Exception: I don't know what quadrant this is in!
+                    Traceback (most recent call last):
+                      File "/work/quadrant/./quadrant.py", line 10, in <module>
+                        raise Exception("I don't know what quadrant this is in!")
+                    Exception: I don't know what quadrant this is in!
 
-                        Input:
-                    "#}),
-                )
-                .assert(StdOut, contains("Saving input to"))
-                .assert(StdOut, contains("Saving your solution's output to"))
-                .assert(StdOut, contains("The saved files can be found in"));
+                    Input:
+                    \d+
+                    \d+
+
+                    Saving input to \d+-runtime-error.in
+                    Saving your solution's output to \d+-runtime-error.output
+
+                    The saved files can be found in /work/quadrant/./debug/saved
+                "#}),
+            );
         }
         .boxed()
     }));

--- a/tests/kitty-cli/debug/input.rs
+++ b/tests/kitty-cli/debug/input.rs
@@ -1,0 +1,113 @@
+use futures_util::FutureExt;
+
+use crate::helpers::{
+    contains, make_standard_setup, run_with_sandbox,
+    OutputSource::{StdErr, StdOut},
+};
+
+#[test]
+fn input_generator_finishes_on_valid_solution() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+
+            env.run("cd quadrant && kitty debug input")
+                .await
+                .assert(StdOut, contains("Running test 1/100..."))
+                .assert(
+                    StdOut,
+                    contains(indoc::indoc! {r#"
+                        Running test 100/100... ✅
+
+                        Passed all 100 test cases. Running times:
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn input_generator_shows_error_if_solution_crashes() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.copy(
+                "./tests/kitty-cli/data/quadrant-runtime-error.py",
+                "/work/quadrant/quadrant.py",
+            );
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+
+            env.run("cd quadrant && kitty debug input")
+                .await
+                .assert(StdOut, contains("Running test 1/100..."))
+                .assert(StdOut, contains(""))
+                .assert(
+                    StdOut,
+                    contains(indoc::indoc! {r#"
+                        /100... ❌
+
+                        Runtime error:
+
+                        Traceback (most recent call last):
+                          File "/work/quadrant/./quadrant.py", line 10, in <module>
+                            raise Exception("I don't know what quadrant this is in!")
+                        Exception: I don't know what quadrant this is in!
+
+                        Input:
+                    "#}),
+                )
+                .assert(StdOut, contains("Saving input to"))
+                .assert(StdOut, contains("Saving your solution's output to"))
+                .assert(StdOut, contains("The saved files can be found in"));
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn input_generator_shows_error_if_generator_fails() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+            env.copy(
+                "./tests/kitty-cli/data/generators/quadrant-buggy-input-generator.py",
+                "/work/quadrant/debug/input.py",
+            );
+
+            env.run("cd quadrant && kitty debug input")
+                .await
+                .assert(StdOut, contains("Running test 1/100... ❌"))
+                .assert(
+                    StdErr,
+                    contains(indoc::indoc! {r#"
+                        Error: Your input generator exited with a non-zero exit code (exit status: 1).
+
+                        Generator output:
+                        42
+                        Traceback (most recent call last):
+                          File "/work/quadrant/./debug/input.py", line 2, in <module>
+                            raise Exception("Buggy input generator")
+                        Exception: Buggy input generator
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}

--- a/tests/kitty-cli/debug/input.rs
+++ b/tests/kitty-cli/debug/input.rs
@@ -23,10 +23,10 @@ fn input_generator_finishes_on_valid_solution() {
                 .assert(StdOut, contains("Running test 1/100..."))
                 .assert(
                     StdOut,
-                    contains(indoc::indoc! {r#"
+                    matches_regex(indoc::indoc! {r#"
                         Running test 100/100... ✅
 
-                        Passed all 100 test cases. Running times:
+                        Passed all 100 test cases. Running times: min \d+.\d+s, max \d+.\d+s, average \d+.\d+s.
                     "#}),
                 );
         }

--- a/tests/kitty-cli/debug/input.rs
+++ b/tests/kitty-cli/debug/input.rs
@@ -59,13 +59,13 @@ fn input_generator_shows_error_if_solution_crashes() {
                     Runtime error:
 
                     Traceback (most recent call last):
-                      File "/work/quadrant/./quadrant.py", line 10, in <module>
+                      File "/work/quadrant/./quadrant.py", line 6, in <module>
                         raise Exception("I don't know what quadrant this is in!")
                     Exception: I don't know what quadrant this is in!
 
                     Input:
-                    \d+
-                    \d+
+                    -?\d+
+                    -?\d+
 
                     Saving input to \d+-runtime-error.in
                     Saving your solution's output to \d+-runtime-error.output
@@ -73,6 +73,26 @@ fn input_generator_shows_error_if_solution_crashes() {
                     The saved files can be found in /work/quadrant/./debug/saved
                 "#}),
             );
+        }
+        .boxed()
+    }));
+}
+
+#[test]
+fn missing_input_generator_shows_helpful_message() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+            env.run("cd /work/quadrant && mkdir debug").await;
+
+            env.run("cd quadrant && kitty debug input")
+                .await
+                .assert(
+                    StdErr,
+                    contains("Error: No input generator file found in the debug folder: /work/quadrant/./debug. See the help message for how to create one."),
+                );
         }
         .boxed()
     }));

--- a/tests/kitty-cli/debug/mod.rs
+++ b/tests/kitty-cli/debug/mod.rs
@@ -1,0 +1,1 @@
+mod input;

--- a/tests/kitty-cli/debug/mod.rs
+++ b/tests/kitty-cli/debug/mod.rs
@@ -1,1 +1,25 @@
+use futures_util::FutureExt;
+
+use crate::helpers::{contains, make_standard_setup, run_with_sandbox, OutputSource::StdErr};
+
+mod answer;
 mod input;
+
+#[test]
+fn missing_debug_folder_shows_helpful_message() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            make_standard_setup(&env).await;
+
+            env.copy("./tests/kitty-cli/data/quadrant", "/work/quadrant");
+
+            env.run("cd quadrant && kitty debug input").await.assert(
+                StdErr,
+                contains(
+                    "Error: You don't have a debug folder. Create it at: /work/quadrant/./debug",
+                ),
+            );
+        }
+        .boxed()
+    }));
+}

--- a/tests/kitty-cli/main.rs
+++ b/tests/kitty-cli/main.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 mod config;
+mod debug;
 mod get;
 mod langs;
 mod submit;

--- a/tests/kitty-cli/test.rs
+++ b/tests/kitty-cli/test.rs
@@ -84,7 +84,7 @@ fn runtime_error_is_shown() {
                     Runtime error:
 
                     Traceback (most recent call last):
-                      File "/work/quadrant/./quadrant.py", line 10, in <module>
+                      File "/work/quadrant/./quadrant.py", line 6, in <module>
                         raise Exception("I don't know what quadrant this is in!")
                     Exception: I don't know what quadrant this is in!
 

--- a/tests/kitty-cli/test.rs
+++ b/tests/kitty-cli/test.rs
@@ -82,11 +82,11 @@ fn runtime_error_is_shown() {
 
                     test 1 ... ❌
                     Runtime error:
+
                     Traceback (most recent call last):
                       File "/work/quadrant/./quadrant.py", line 10, in <module>
                         raise Exception("I don't know what quadrant this is in!")
                     Exception: I don't know what quadrant this is in!
-
 
                     test 2 ... ✅
 


### PR DESCRIPTION
*Snippet of the README explaining the feature:*

There may be cases where you want to automatically generate test cases with a program. To do this, `kitty` has the `debug input` command that will feed whatever your input generator outputs into your solution program:

```sh
kitty debug input
```

The logical equivalence of this command is running `run-solution < $(run-input-generator)` *n* times or until a runtime error occurs.

See the help message for how to create the input generator and specify the number of iterations. By default, `kitty` uses the file at `<solution folder>/debug/input.<extension>`.

On top of this, you can use `kitty` to automatically check your solution's answer against another implementation. For instance, you may be able to implement a correct but slow solution. When developing the faster solution, you can use the slow solution to check that the new version outputs the correct answers across automatically generated inputs:

```sh
kitty debug answer
```

This is logically equivalent to `kitty test` but where the `.in` file is replaced with an input generator program and the `.ans` file is replaced with an answer validator program.

See the help message for more information. By default, `kitty` uses the file at `<solution folder>/debug/answer.<extension>`.

Closes #65.

## TODO
- [x] Write integration tests
- [x] Update README with example
- [x] Write input/output to files for wrong answer/runtime error
- [x] Move more of the input/answer generator logic into the `TestCaseIO` implementation
- [x] Measure time to run inside `run_test` to avoid compile time being counted
- [x] Resolve TODO comments