### PR TITLE
Allow users to set kitty's config dir via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ which will create a file called `<PROBLEM ID>.java` that you can use.
 Alternatively, you can set the default language for kitty to use so that you don't need to specify the language argument every time you fetch a problem. See the following configuration section for more.
 
 ### Configuration
+All configuration is stored in kitty's configuration folder. To find the location of kitty's configuration folder, run `kitty config location`. 
+
+If you want to use another location for the configuration folder, you can use the `KATTIS_KITTY_CONFIG_DIR` environment variable. This may be useful for those of you who use the kitty terminal. For example:
+```
+KATTIS_KITTY_CONFIG_DIR=~/dotfiles/my-kitty-cli-config-dir kitty config location
+```
+Naturally, you can add this environment variable to your shell of choice.
+
 #### `.kattisrc`
 
 Kattis provides you with a `.kattisrc` file, which contains:
@@ -83,8 +91,6 @@ You can download your personal `.kattisrc` at <https://open.kattis.com/download/
 Kitty does not store information about programming languages (how to run or compile a program, file extensions, etc.) - instead it is you who must define which programming languages kitty can use. This also means you are completely free to specify compiler flags, add new languages and so forth.
 
 The configuration is done via a YAML file called `kitty.yml` located in your kitty configuration folder. This repository contains an example configuration (with comments describing the different options): [kitty.yml](https://github.com/avborup/kitty/blob/master/kitty.yml). Here you will find configurations for a fair amount of languages supported by Kattis. Feel free to simply download that file as it may fit your needs just fine.
-
-To find the location of kitty's configuration folder, run `kitty config location`. 
 
 To see which languages kitty has picked up on from your configuration file, run
 ```

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -5,7 +5,6 @@ use eyre::Context;
 
 use crate::{
     cli::{ConfigArgs, ConfigSubcommand},
-    config::{self, Config},
     App,
 };
 
@@ -20,23 +19,21 @@ pub async fn config(app: &App, config_args: &ConfigArgs) -> crate::Result<()> {
     }
 }
 
-fn init_config_files(_app: &App) -> crate::Result<()> {
-    fs::create_dir_all(Config::templates_dir_path())?;
+fn init_config_files(app: &App) -> crate::Result<()> {
+    fs::create_dir_all(app.config.templates_dir_path())?;
 
     println!(
         indoc::indoc! {"
             Initialised config directory at {}.
             You should place your .kattisrc and kitty.yml here."
         },
-        Config::dir_path().display().to_string().underline()
+        app.config.config_dir.display().to_string().underline()
     );
 
     Ok(())
 }
 
-fn show_config_location(_app: &App) -> crate::Result<()> {
-    let config_dir = config::Config::dir_path();
-
+fn show_config_location(app: &App) -> crate::Result<()> {
     println!(
         indoc::indoc! {"
             Your config files should go in this directory:
@@ -48,10 +45,10 @@ fn show_config_location(_app: &App) -> crate::Result<()> {
              - Your kitty.yml file:   {}
              - Your templates folder: {}
         "},
-        config_dir.display().to_string().underline(),
-        Config::kattisrc_path().display(),
-        Config::config_file_path().display(),
-        Config::templates_dir_path().display()
+        app.config.config_dir.display().to_string().underline(),
+        app.config.kattisrc_path().display(),
+        app.config.config_file_path().display(),
+        app.config.templates_dir_path().display()
     );
 
     Ok(())

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -11,7 +11,7 @@ use zip::ZipArchive;
 
 use crate::{
     cli::GetArgs,
-    config::{language::Language, Config},
+    config::language::Language,
     problem::{make_problem_sample_tests_zip_url, make_problem_url, problem_id_is_legal},
     solution::get_test_dir,
     App,
@@ -140,7 +140,7 @@ fn populate_template(
         };
 
     if let Some(language) = lang {
-        copy_template_with_lang(args, solution_dir, language)
+        copy_template_with_lang(app, args, solution_dir, language)
             .wrap_err("Failed to populate the solution folder with your template")?;
     }
 
@@ -148,11 +148,12 @@ fn populate_template(
 }
 
 fn copy_template_with_lang(
+    app: &App,
     args: &GetArgs,
     solution_dir: impl AsRef<Path>,
     lang: &Language,
 ) -> crate::Result<()> {
-    let templates_dir = Config::templates_dir_path();
+    let templates_dir = app.config.templates_dir_path();
     let template_file = templates_dir
         .join("template")
         .with_extension(lang.file_ext());

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -275,7 +275,6 @@ impl SubmissionStatus {
 
         let test_case_statuses: Vec<_> = html
             .select(&Selector::parse(".testcase i.status-icon").unwrap())
-            .into_iter()
             .map(|el| TestCaseStatus::from_test_case_icon_html(el.value()))
             .collect();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use eyre::ensure;
 use kattisrc::Kattisrc;
 
 use crate::utils::get_full_path;
@@ -25,7 +24,7 @@ pub struct Config {
 impl Config {
     pub fn load() -> crate::Result<Self> {
         let config_dir =
-            Self::get_config_dir_path_from_env()?.unwrap_or_else(Self::default_config_dir_path);
+            Self::get_config_dir_path_from_env().unwrap_or_else(Self::default_config_dir_path);
 
         let kattisrc = Kattisrc::from_file(Self::kattisrc_path_with_dir(&config_dir))?;
         let yml_config = parse_config_from_yaml_file(Self::config_file_path_with_dir(&config_dir))?;
@@ -45,19 +44,8 @@ impl Config {
             .ok_or_else(|| eyre::eyre!("Could not find .kattisrc file. You must download your .kattisrc file from https://open.kattis.com/download/kattisrc and save it at '{}'", self.kattisrc_path().display()))
     }
 
-    pub fn get_config_dir_path_from_env() -> crate::Result<Option<PathBuf>> {
-        match env::var("KATTIS_KITTY_CONFIG_DIR").map(PathBuf::from) {
-            Ok(path) => {
-                ensure!(
-                    path.is_dir(),
-                    "The config directory path '{}' is not a directory",
-                    path.display()
-                );
-
-                Ok(Some(path))
-            }
-            Err(_) => Ok(None),
-        }
+    pub fn get_config_dir_path_from_env() -> Option<PathBuf> {
+        env::var("KATTIS_KITTY_CONFIG_DIR").map(PathBuf::from).ok()
     }
 
     /// Gets kitty's config directory. The location of this directory will vary

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,9 @@
 use std::{
-    env::consts::EXE_EXTENSION,
+    env::{self, consts::EXE_EXTENSION},
     path::{Path, PathBuf},
 };
 
+use eyre::ensure;
 use kattisrc::Kattisrc;
 
 use crate::utils::get_full_path;
@@ -16,17 +17,22 @@ mod parser;
 #[derive(Debug, Default)]
 pub struct Config {
     pub kattisrc: Option<Kattisrc>,
+    pub config_dir: PathBuf,
     pub default_language: Option<String>,
     pub languages: Vec<Language>,
 }
 
 impl Config {
     pub fn load() -> crate::Result<Self> {
-        let kattisrc = Kattisrc::from_file(Self::kattisrc_path())?;
-        let yml_config = parse_config_from_yaml_file(Self::config_file_path())?;
+        let config_dir =
+            Self::get_config_dir_path_from_env()?.unwrap_or_else(Self::default_config_dir_path);
+
+        let kattisrc = Kattisrc::from_file(Self::kattisrc_path_with_dir(&config_dir))?;
+        let yml_config = parse_config_from_yaml_file(Self::config_file_path_with_dir(&config_dir))?;
 
         let config = Config {
             kattisrc,
+            config_dir,
             ..yml_config
         };
 
@@ -36,7 +42,22 @@ impl Config {
     pub fn try_kattisrc(&self) -> crate::Result<&Kattisrc> {
         self.kattisrc
             .as_ref()
-            .ok_or_else(|| eyre::eyre!("Could not find .kattisrc file. You must download your .kattisrc file from https://open.kattis.com/download/kattisrc and save it at '{}'", Self::kattisrc_path().display()))
+            .ok_or_else(|| eyre::eyre!("Could not find .kattisrc file. You must download your .kattisrc file from https://open.kattis.com/download/kattisrc and save it at '{}'", self.kattisrc_path().display()))
+    }
+
+    pub fn get_config_dir_path_from_env() -> crate::Result<Option<PathBuf>> {
+        match env::var("KATTIS_KITTY_CONFIG_DIR").map(PathBuf::from) {
+            Ok(path) => {
+                ensure!(
+                    path.is_dir(),
+                    "The config directory path '{}' is not a directory",
+                    path.display()
+                );
+
+                Ok(Some(path))
+            }
+            Err(_) => Ok(None),
+        }
     }
 
     /// Gets kitty's config directory. The location of this directory will vary
@@ -44,22 +65,34 @@ impl Config {
     ///  - `%APPDATA%/kitty` on Windows
     ///  - `~/.config/kitty` on Linux
     ///  - `~/Library/Application Support/kitty` on macOS
-    pub fn dir_path() -> PathBuf {
+    pub fn default_config_dir_path() -> PathBuf {
         platform_dirs::AppDirs::new(Some("kitty"), false)
             .expect("failed to find where the kitty config directory should be located")
             .config_dir
     }
 
-    pub fn kattisrc_path() -> PathBuf {
-        Self::dir_path().join(".kattisrc")
+    pub fn kattisrc_path(&self) -> PathBuf {
+        Self::kattisrc_path_with_dir(&self.config_dir)
     }
 
-    pub fn config_file_path() -> PathBuf {
-        Self::dir_path().join("kitty.yml")
+    pub fn config_file_path(&self) -> PathBuf {
+        Self::config_file_path_with_dir(&self.config_dir)
     }
 
-    pub fn templates_dir_path() -> PathBuf {
-        Self::dir_path().join("templates")
+    pub fn templates_dir_path(&self) -> PathBuf {
+        Self::templates_dir_path_with_dir(&self.config_dir)
+    }
+
+    pub fn kattisrc_path_with_dir(dir: impl AsRef<Path>) -> PathBuf {
+        dir.as_ref().join(".kattisrc")
+    }
+
+    pub fn config_file_path_with_dir(dir: impl AsRef<Path>) -> PathBuf {
+        dir.as_ref().join("kitty.yml")
+    }
+
+    pub fn templates_dir_path_with_dir(dir: impl AsRef<Path>) -> PathBuf {
+        dir.as_ref().join("templates")
     }
 
     pub fn lang_from_file_ext(&self, file_ext: &str) -> Option<&Language> {

--- a/tests/kitty-cli/config/location.rs
+++ b/tests/kitty-cli/config/location.rs
@@ -1,0 +1,27 @@
+use futures_util::FutureExt;
+
+use crate::helpers::{equals, run_with_sandbox, OutputSource::StdOut};
+
+#[test]
+fn config_dir_is_overridden() {
+    run_with_sandbox(Box::new(|env| {
+        async move {
+            env.run("KATTIS_KITTY_CONFIG_DIR=/root/kitty-config-dir kitty config location")
+                .await
+                .assert(
+                    StdOut,
+                    equals(indoc::indoc! {r#"
+                        Your config files should go in this directory:
+
+                            /root/kitty-config-dir
+
+                        More specifically:
+                         - Your .kattisrc file:   /root/kitty-config-dir/.kattisrc
+                         - Your kitty.yml file:   /root/kitty-config-dir/kitty.yml
+                         - Your templates folder: /root/kitty-config-dir/templates
+                    "#}),
+                );
+        }
+        .boxed()
+    }));
+}

--- a/tests/kitty-cli/config/mod.rs
+++ b/tests/kitty-cli/config/mod.rs
@@ -1,1 +1,2 @@
 mod init;
+mod location;


### PR DESCRIPTION
Some users were having issues with the kitty terminal and this kitty cli sharing the same config directory. Thus I've added an environment variable that allows users to override which directory is used.