### PR TITLE
Add flag to show stderr in tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,6 +170,10 @@ pub struct TestArgs {
     /// glob pattern.
     #[arg(short = 'F', long)]
     pub filter: Option<String>,
+
+    /// Shows the solution's stderr output in case of a wrong answer.
+    #[arg(short = 'e', long, default_value_t = false)]
+    stderr: bool,
 }
 
 /// Opens a problem in the browser
@@ -294,4 +298,13 @@ pub struct DebugAnswerArgs {
     /// 'answer' will be used (for example 'answer.py').
     #[arg(short, long = "answer-validator")]
     pub answer_validator_path: Option<PathBuf>,
+}
+
+impl KittyArgs {
+    pub fn should_show_wrong_answer_stderr(&self) -> bool {
+        match &self.subcommand {
+            KittySubcommand::Test(args) => args.stderr,
+            _ => false,
+        }
+    }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -74,7 +74,7 @@ pub async fn debug(app: &App, args: &DebugArgs) -> crate::Result<()> {
         if let Err(failure) = outcome {
             println!("{FAILURE}\n");
 
-            failure.test_case_error.print();
+            failure.test_case_error.print(app);
 
             println!("{}:", "Input".bright_red());
             println!("{}\n", failure.test_case_error.input().trim_end());

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -93,7 +93,7 @@ fn run_tests(
         println!();
 
         if let Err(test_case_error) = outcome {
-            test_case_error.print();
+            test_case_error.print(app);
         }
     }
 

--- a/src/test_io.rs
+++ b/src/test_io.rs
@@ -64,6 +64,7 @@ where
             input,
             expected: expected_answer.trim_end().to_string(),
             actual: stdout.trim_end().to_string(),
+            stderr: stderr.trim_end().to_string(),
         }));
     }
 
@@ -196,6 +197,7 @@ pub enum TestCaseError {
         input: String,
         expected: String,
         actual: String,
+        stderr: String,
     },
     RuntimeError {
         input: String,
@@ -212,15 +214,23 @@ impl TestCaseError {
         }
     }
 
-    pub fn print(&self) {
+    pub fn print(&self, app: &App) {
         match self {
             TestCaseError::WrongAnswer {
-                expected, actual, ..
+                expected,
+                actual,
+                stderr,
+                ..
             } => {
                 println!("{}", "Expected:".underline());
                 println!("{}\n", expected.trim_end());
                 println!("{}", "Actual:".underline());
                 println!("{}\n", actual.trim_end());
+
+                if app.args.should_show_wrong_answer_stderr() {
+                    println!("{}", "Stderr:".underline());
+                    println!("{}\n", stderr.trim_end());
+                }
             }
             TestCaseError::RuntimeError { stdout, stderr, .. } => {
                 println!("{}:", "Runtime error".bright_red());

--- a/tests/kitty-cli/data/quadrant-wrong-answer.py
+++ b/tests/kitty-cli/data/quadrant-wrong-answer.py
@@ -1,6 +1,8 @@
-from sys import stdin
+from sys import stdin, stderr
 
 x, y = int(next(stdin)), int(next(stdin))
+
+print(f"Input was ({x}, {y})", file=stderr)
 
 if x < 0 and y < 0:
     print(1)


### PR DESCRIPTION
You can now use `--stderr`/`-e` to show the stderr for wrong answers.

Closes #62.