### PR TITLE
Fix failed submission status request

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -243,9 +243,6 @@ enum SubmissionStage {
 struct SubmissionStatusResponse {
     status_id: u64,
     testcase_index: u64,
-    testdata_groups_html: String,
-    feedback_html: String,
-    judge_feedback_html: String,
     row_html: String,
 }
 


### PR DESCRIPTION
Kattis changed their API to return different fields. Specifically, they removed fields from the response that we expected to be present, leading to an error.

Luckily, we do not actually use those missing fields, so no logic has to be changed.

The error was:
```
Submitted solution to https://open.kattis.com/submissions/....

Error: Failed to get submission status from Kattis

Run with --verbose for more information
```
And the root cause is pretty obvious from the verbose output:
```
Submitted solution to https://open.kattis.com/submissions/....

Error:
   0: Failed to get submission status from Kattis
   1: Failed to read submission status response from Kattis
   2: error decoding response body: missing field `testdata_groups_html` at line 11 column 661
   3: missing field `testdata_groups_html` at line 11 column 661

Location:
   .../kitty/src/commands/submit.rs:266
```